### PR TITLE
feat(events): Publish UserRegisteredEvent to Kafka from UserRegisterS…

### DIFF
--- a/Auth-Service/src/main/java/com/axconstantino/auth/application/service/EventPublisherService.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/application/service/EventPublisherService.java
@@ -1,4 +1,53 @@
 package com.axconstantino.auth.application.service;
 
+import com.axconstantino.auth.domain.event.UserRegisteredEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class EventPublisherService {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${spring.kafka.topic.user-registered}")
+    private String userRegisteredTopic;
+
+    /**
+     * Publishes a RegisteredUserEvent to Kafka asynchronously.
+     * The user's ID is used as the message key to ensure that events
+     * from the same user are sent to the same partition, preserving order.
+     *
+     * @param event The event payload containing the user's registration details. Must not be null.
+     * @apiNote This method operates in a "fire-and-forget" mode. The result of the send operation is handled
+     * asynchronously via logging. Requires the KafkaTemplate to be configured with a serializer
+     * compatible with RegisteredUserEvent, such as JsonSerializer.
+     */
+    public void publishUserRegisteredEvent(UserRegisteredEvent event) {
+        Assert.notNull(event, "UserRegisteredEvent must not be null");
+
+        try {
+            String key = event.userId().toString();
+            log.info("Trying to publish event for registered user with email: {}", event.email());
+
+            kafkaTemplate.send(userRegisteredTopic, key, event)
+                    .thenAccept(result ->
+                            log.info("Event successfully published to user ID {}. Topic: {}, Partition: {}, Offset: {}",
+                                    key,
+                                    result.getRecordMetadata().topic(),
+                                    result.getRecordMetadata().partition(),
+                                    result.getRecordMetadata().offset()))
+                    .exceptionally(ex -> {
+                        log.error("Failed to publish event for user ID {} asynchronously.", key, ex);
+                        return null;
+                    });
+        } catch (Exception e) {
+            log.error("Unexpected synchronous error while attempting to send event for user ID {}: {}", event.userId(), e.getMessage(), e);
+        }
+    }
 }

--- a/Auth-Service/src/main/java/com/axconstantino/auth/application/service/LoginUserService.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/application/service/LoginUserService.java
@@ -21,10 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class LoginUserService implements LoginUser {
 
+    private final JwtProvider jwtProvider;
     private final TokenService tokenService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final JwtProvider jwtProvider;
 
     @Override
     @Transactional

--- a/Auth-Service/src/main/java/com/axconstantino/auth/application/service/RegisterUserService.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/application/service/RegisterUserService.java
@@ -4,6 +4,7 @@ import com.axconstantino.auth.application.command.AuthenticateCommand;
 import com.axconstantino.auth.application.command.RegisterCommand;
 import com.axconstantino.auth.application.dto.TokenResponse;
 import com.axconstantino.auth.application.usecase.RegisterUser;
+import com.axconstantino.auth.domain.event.UserRegisteredEvent;
 import com.axconstantino.auth.domain.model.Role;
 import com.axconstantino.auth.domain.model.Token;
 import com.axconstantino.auth.domain.model.TokenType;
@@ -29,6 +30,7 @@ public class RegisterUserService implements RegisterUser {
     private final UserRepository repository;
     private final TokenService tokenService;
     private final PasswordEncoder passwordEncoder;
+    private final EventPublisherService eventPublisher;
 
 
     /**
@@ -88,6 +90,12 @@ public class RegisterUserService implements RegisterUser {
         repository.save(user);
         tokenService.saveTokenInCache(user, accessToken);
         log.info("User registered successfully. ID: {}, Email: {}", user.getId(), user.getEmail());
+
+        eventPublisher.publishUserRegisteredEvent(new UserRegisteredEvent(
+                user.getId(),
+                user.getName(),
+                user.getEmail()
+        ));
 
         return new TokenResponse(accessToken.getToken(), refreshToken.getToken());
     }

--- a/Auth-Service/src/main/java/com/axconstantino/auth/domain/event/UserRegisteredEvent.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/domain/event/UserRegisteredEvent.java
@@ -3,13 +3,13 @@ package com.axconstantino.auth.domain.event;
 import java.time.Instant;
 import java.util.UUID;
 
-public record RegisteredUserEvent(
+public record UserRegisteredEvent(
         UUID userId,
         String name,
         String email,
         Instant timestamp
 ) {
-    public RegisteredUserEvent (UUID userId, String name, String email) {
+    public UserRegisteredEvent(UUID userId, String name, String email) {
         this(userId, name, email, Instant.now());
     }
 }


### PR DESCRIPTION
…ervice

- Implemented asynchronous publishing of UserRegisteredEvent using KafkaTemplate in EventPublisherService.
- Ensures that events from the same user are directed to the same Kafka partition using the user ID as the key.
- Added proper logging for success and failure cases, including asynchronous exception handling.
- The event is now triggered from RegisterUserService upon successful user registration.