### PR TITLE
feat(auth): add soft delete support and implement logout and account deletion endpoints

### DIFF
--- a/Auth-Service/src/main/java/com/axconstantino/auth/application/service/DeleteUserService.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/application/service/DeleteUserService.java
@@ -1,0 +1,43 @@
+package com.axconstantino.auth.application.service;
+
+import com.axconstantino.auth.application.usecase.DeleteUser;
+import com.axconstantino.auth.domain.event.UserDeletedEvent;
+import com.axconstantino.auth.domain.exception.UserNotFoundException;
+import com.axconstantino.auth.domain.model.User;
+import com.axconstantino.auth.domain.repository.UserRepository;
+import com.axconstantino.auth.infrastructure.kafka.EventPublisherService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Service responsible for deleting a user from the system.
+ * <p>
+ * This service handles the deletion of a user by their ID, revokes all associated tokens,
+ * and publishes an event indicating that the user has been deleted.
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeleteUserService implements DeleteUser {
+
+    private final UserRepository repository;
+    private final TokenService tokenService;
+    private final EventPublisherService eventPublisherService;
+
+    @Override
+    @Transactional
+    public void execute(UUID userID) {
+        User user = repository.findById(userID)
+                .orElseThrow(() -> new UserNotFoundException("User not found with ID: " + userID));
+
+        log.info("Deleting user with ID: {}", userID);
+        repository.deleteById(userID);
+        tokenService.revokeAllUserTokens(user);
+        eventPublisherService.publishUserDeletedEvent(new UserDeletedEvent(userID));
+    }
+}

--- a/Auth-Service/src/main/java/com/axconstantino/auth/application/service/LogoutService.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/application/service/LogoutService.java
@@ -1,0 +1,69 @@
+package com.axconstantino.auth.application.service;
+
+import com.axconstantino.auth.application.usecase.Logout;
+import com.axconstantino.auth.domain.exception.BadCredentialsException;
+import com.axconstantino.auth.domain.repository.TokenRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service responsible for handling user logout by revoking the access token.
+ * <p>
+ * The logout process includes:
+ * <ul>
+ *     <li>Extracting the Bearer token from the Authorization header.</li>
+ *     <li>Validating and locating the token in the database.</li>
+ *     <li>Revoking the token and marking it as invalid.</li>
+ *     <li>Removing the token from Redis cache to prevent reuse.</li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * This service is transactional to ensure the token revocation is committed to the database.
+ * </p>
+ *
+ * <p>
+ * If the Authorization header is missing, malformed, or the token is not found in the system,
+ * a {@link BadCredentialsException} is thrown.
+ * </p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LogoutService implements Logout {
+    private final TokenRepository tokenRepository;
+    private final TokenService tokenService;
+
+
+    /**
+     * Executes the logout operation by revoking the current access token.
+     *
+     * @param request The HTTP request containing the Bearer token in the Authorization header.
+     * @throws BadCredentialsException if the token is missing, malformed, or not found in the system.
+     */
+    @Override
+    @Transactional
+    public void execute(HttpServletRequest request) {
+        final String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.warn("[LogoutService] Missing or invalid Authorization header");
+            throw new BadCredentialsException("Invalid token");
+        }
+
+        String token = authHeader.substring(7);
+
+        tokenRepository.findByToken(token).ifPresentOrElse(storedToken -> {
+            storedToken.revoke();
+            tokenRepository.save(storedToken);
+            tokenService.deleteTokenFromCache(token);
+            log.info("[LogoutService] Token successfully revoked");
+        }, () -> {
+            log.warn("[LogoutService] Token not found in DB: {}", token);
+            throw new BadCredentialsException("Invalid token");
+        });
+    }
+}

--- a/Auth-Service/src/main/java/com/axconstantino/auth/application/service/TokenService.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/application/service/TokenService.java
@@ -115,4 +115,10 @@ public class TokenService {
         tokenRepository.saveAll(validUserTokens);
         log.debug("[TokenService] Revoked tokens saved in database for user ID: {}", user.getId());
     }
+
+    public void deleteTokenFromCache(String token) {
+        cacheRepository.delete(token);
+        log.debug("[TokenService] Token deleted from cache: {}", token);
+    }
+
 }

--- a/Auth-Service/src/main/java/com/axconstantino/auth/application/usecase/DeleteUser.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/application/usecase/DeleteUser.java
@@ -1,0 +1,7 @@
+package com.axconstantino.auth.application.usecase;
+
+import java.util.UUID;
+
+public interface DeleteUser {
+    void execute(UUID userID);
+}

--- a/Auth-Service/src/main/java/com/axconstantino/auth/application/usecase/Logout.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/application/usecase/Logout.java
@@ -1,0 +1,7 @@
+package com.axconstantino.auth.application.usecase;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface Logout {
+    void execute(HttpServletRequest request);
+}

--- a/Auth-Service/src/main/java/com/axconstantino/auth/domain/event/UserDeletedEvent.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/domain/event/UserDeletedEvent.java
@@ -1,0 +1,6 @@
+package com.axconstantino.auth.domain.event;
+
+import java.util.UUID;
+
+public record UserDeletedEvent(UUID userId) {
+}

--- a/Auth-Service/src/main/java/com/axconstantino/auth/domain/model/User.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/domain/model/User.java
@@ -1,5 +1,6 @@
 package com.axconstantino.auth.domain.model;
 
+import java.time.Instant;
 import java.util.*;
 
 public class User {
@@ -11,20 +12,22 @@ public class User {
     private final Set<Role> roles;
     private boolean active;
     private boolean emailVerified;
+    private Instant deletedAt;
     private final Set<Token> tokens;
 
     public static User register(String userName, String email, String password, Set<Role> roles) {
-        return new User(UUID.randomUUID(), userName, email, password, roles != null ? roles : new HashSet<>(), true, false, new HashSet<>());
+        return new User(UUID.randomUUID(), userName, email, password, roles != null ? roles : new HashSet<>(), true, false, null, new HashSet<>());
     }
 
     public User(UUID id, String name, String email, String password, Set<Role> roles,
-                boolean active, boolean emailVerified, Set<Token> tokens) {
+                boolean active, boolean emailVerified, Instant deletedAt, Set<Token> tokens) {
         this.id = id;
         this.email = Objects.requireNonNull(email);
         this.password = Objects.requireNonNull(password);
         this.roles = new HashSet<>(Objects.requireNonNull(roles));
         this.active = active;
         this.emailVerified = emailVerified;
+        this.deletedAt = deletedAt;
         this.tokens = new HashSet<>(Objects.requireNonNull(tokens));
     }
 
@@ -35,6 +38,7 @@ public class User {
     public Set<Role> getRoles() { return Collections.unmodifiableSet(roles); }
     public boolean isActive() { return active; }
     public boolean isEmailVerified() { return emailVerified; }
+    public Instant getDeletedAt() { return deletedAt; }
     public Set<Token> getTokens() { return Collections.unmodifiableSet(tokens); }
 
     public boolean isAdmin() {

--- a/Auth-Service/src/main/java/com/axconstantino/auth/domain/repository/UserRepository.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/domain/repository/UserRepository.java
@@ -16,5 +16,6 @@ public interface UserRepository {
 
     void save(User user);
 
+    void deleteById(UUID id);
 }
 

--- a/Auth-Service/src/main/java/com/axconstantino/auth/infrastructure/kafka/EventPublisherService.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/infrastructure/kafka/EventPublisherService.java
@@ -40,6 +40,9 @@ public class EventPublisherService {
     @Value("${spring.kafka.topic.email-verification}")
     private String emailVerificationTopic;
 
+    @Value("${spring.kafka.topic.user-deleted}")
+    private String userDeletedTopic;
+
     /**
      * Publishes a {@link UserRegisteredEvent} to the Kafka topic configured via {@code spring.kafka.topic.user-registered}.
      *
@@ -68,6 +71,16 @@ public class EventPublisherService {
     public void publishEmailVerificationEvent(EmailVerificationEvent event) {
         Assert.notNull(event, "EmailVerificationEvent must not be null");
         publishEvent(emailVerificationTopic, event.email(), event);
+    }
+
+    /**
+     * Publishes a {@link UserDeletedEvent} to the Kafka topic configured via {@code spring.kafka.topic.user-deleted}.
+     *
+     * @param event the user deletion event to be published. Must not be null.
+     */
+    public void publishUserDeletedEvent(UserDeletedEvent event) {
+        Assert.notNull(event, "UserDeletedEvent must not be null");
+        publishEvent(userDeletedTopic, event.userId().toString(), event);
     }
 
     /**

--- a/Auth-Service/src/main/java/com/axconstantino/auth/infrastructure/persistence/jpa/adapter/UserRepositoryJpaAdapter.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/infrastructure/persistence/jpa/adapter/UserRepositoryJpaAdapter.java
@@ -43,4 +43,9 @@ public class UserRepositoryJpaAdapter implements UserRepository {
     public void save(User user) {
         jpaRepo.save(mapper.toEntity(user));
     }
+
+    @Override
+    public void deleteById(UUID id) {
+        jpaRepo.deleteById(id);
+    }
 }

--- a/Auth-Service/src/main/java/com/axconstantino/auth/infrastructure/persistence/jpa/entity/UserEntity.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/infrastructure/persistence/jpa/entity/UserEntity.java
@@ -6,7 +6,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
+import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 
@@ -17,6 +20,8 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@SQLDelete(sql = "UPDATE users SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
 public class UserEntity {
 
     @Id
@@ -51,6 +56,9 @@ public class UserEntity {
     @Builder.Default
     @Column(name = "email_verified", nullable = false)
     private boolean emailVerified = false;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
 
     @JsonIgnore
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/Auth-Service/src/main/java/com/axconstantino/auth/web/AuthController.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/web/AuthController.java
@@ -27,6 +27,7 @@ public class AuthController {
     private final ForgotPassword forgotPassword;
     private final RequestEmailVerification requestEmailVerification;
     private final VerifyEmail verifyEmail;
+    private final Logout logout;
 
     @PostMapping("/register")
     public ResponseEntity<TokenResponse> register(@Valid @RequestBody RegisterRequest request, HttpServletRequest httpRequest) {
@@ -49,6 +50,12 @@ public class AuthController {
 
         final TokenResponse response = loginUser.execute(command, httpRequest);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        logout.execute(request);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/refresh-token")

--- a/Auth-Service/src/main/java/com/axconstantino/auth/web/UserController.java
+++ b/Auth-Service/src/main/java/com/axconstantino/auth/web/UserController.java
@@ -6,25 +6,29 @@ import com.axconstantino.auth.application.command.ChangeUserNameCommand;
 import com.axconstantino.auth.application.usecase.ChangeEmail;
 import com.axconstantino.auth.application.usecase.ChangePassword;
 import com.axconstantino.auth.application.usecase.ChangeUserName;
+import com.axconstantino.auth.application.usecase.DeleteUser;
 import com.axconstantino.auth.web.dto.ChangeEmailRequest;
 import com.axconstantino.auth.web.dto.ChangePasswordRequest;
 import com.axconstantino.auth.web.dto.ChangeUserNameRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@PreAuthorize("isAuthenticated()")
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/users/me")
 @RequiredArgsConstructor
 public class UserController {
     private final ChangePassword changePassword;
     private final ChangeEmail changeEmail;
     private final ChangeUserName changeUserName;
+    private final DeleteUser deleteUser;
 
     @PatchMapping("/password")
     public ResponseEntity<Void> changePassword(@AuthenticationPrincipal Jwt principal,
@@ -71,6 +75,13 @@ public class UserController {
 
         changeUserName.execute(command);
 
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/delete-account")
+    public ResponseEntity<Void> deleteAccount(@AuthenticationPrincipal Jwt principal) {
+        UUID userId = UUID.fromString(principal.getSubject());
+        deleteUser.execute(userId);
         return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
This PR introduces support for soft deletion of users and implements key authentication features, including secure logout and account deletion.

### ✨ Features

- ✅ **Soft Delete Support**
  - Applied `@SQLDelete` and `@Where` annotations on `UserEntity` to support logical deletion.
  - Ensures soft-deleted users are excluded from queries automatically.

- 🔐 **Account Deletion**
  - Added `DeleteUser` use case and `DeleteUserService` to handle account deletion.
  - Created `DELETE /delete-account` endpoint to logically delete the authenticated user.
  - Revokes all associated tokens and publishes `UserDeletedEvent` for other services.

- 🚪 **Logout Endpoint**
  - Implemented `LogoutService` to revoke tokens during logout.
  - Tokens are invalidated in the database and evicted from Redis cache.
  - Handles missing or invalid tokens securely with `BadCredentialsException`.
  - Ensures transactional integrity for token revocation.